### PR TITLE
:recycle: Replace `bratlib` with `pybrat`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ spacy-alignments = "^0.9.1"
 numpy = "^1.16"
 levenshtein = "*"
 more-itertools = "*"
-bratlib = { git = "https://github.com/swfarnsworth/bratlib.git", tag = "v0.1.0" }
+pybrat = "^0.1.7"
 mlflow = "^2.6.0"
 psutil = "^7.0.0"
 typer = "^0.15.1"


### PR DESCRIPTION
Replace the unpublished `bratlib` library with `pybrat`, a more recent, typed, and published library that serves the same purpose. This change is needed to be able to publish ArchiTXT to PyPI. This change should have minimal impact, as `pybrat` is functionally equivalent to `bratlib`.