### PR TITLE
:recycle: Rework SciSpaCy entity resolver to remove SpaCy model dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ aiostream = "^0.6.4"
 
 # SpaCy
 scispacy = "^0.5.5"
-en-core-sci-sm = { url = "https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz", optional = true }
 
 # Optional UI dependencies
 streamlit = { version = ">=1.39.0", optional = true }
@@ -58,8 +57,7 @@ nmslib = { git = "https://github.com/nmslib/nmslib.git", subdirectory = "python_
 
 [tool.poetry.extras]
 ui = ["streamlit", "streamlit-agraph", "streamlit-tags"]
-resolver = ["en-core-sci-sm"]
-all = ["streamlit", "streamlit-agraph", "streamlit-tags", "en-core-sci-sm"]
+all = ["streamlit", "streamlit-agraph", "streamlit-tags"]
 
 [tool.poetry.group.dev.dependencies]
 wheel = "^0.45.0"
@@ -84,7 +82,6 @@ antlr4-tools = "^0.2.1"
 streamlit = "*"
 streamlit-agraph = "*"
 streamlit-tags = "*"
-en-core-sci-sm = "*"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3"


### PR DESCRIPTION
This refactor the SciSpaCy entity resolver so it no longer needs a spaCy model and avoid re-parsing the text using the lower-level CandidateGenerator API directly. It will uses less memory and should be faster but it might reduce the resolution of entities, because it skips the extra entity extraction on top of the provided annotation.