### PR TITLE
:sparkles: Add an option for schema-based clustering in `TreeClusterer`

### DIFF
--- a/architxt/cli/__init__.py
+++ b/architxt/cli/__init__.py
@@ -2,6 +2,7 @@ import shutil
 import subprocess
 import warnings
 from contextlib import AbstractContextManager, nullcontext
+from enum import Enum
 from functools import partial
 from pathlib import Path
 
@@ -111,6 +112,11 @@ def cleanup(
             show_metrics(result_metrics)
 
 
+class SimilarityMode(str, Enum):
+    instance = "instance"
+    schema = "schema"
+
+
 @app.command(help="Simplify a bunch of databased together.")
 def simplify(
     files: list[Path] = typer.Argument(..., exists=True, readable=True, help="Path of the data files to load."),
@@ -119,6 +125,10 @@ def simplify(
     decay: float = typer.Option(DECAY, help="The similarity decay factor.", min=0.001),
     epoch: int = typer.Option(100, help="Number of iteration for tree rewriting.", min=1),
     min_support: int = typer.Option(20, help="Minimum support for tree patterns.", min=1),
+    similarity: SimilarityMode = typer.Option(
+        SimilarityMode.instance,
+        help="Mode for similarity calculation. 'instance' uses instance-level similarity, 'schema' uses schema-level similarity.",
+    ),
     workers: int | None = typer.Option(
         None, help="Number of parallel worker processes to use. Defaults to the number of available CPU cores.", min=1
     ),
@@ -153,7 +163,14 @@ def simplify(
             f'[blue]Rewriting {len(forest)} trees with tau={tau}, decay={decay}, epoch={epoch}, min_support={min_support}[/]'
         )
         result_metrics = rewrite(
-            forest, tau=tau, decay=decay, epoch=epoch, min_support=min_support, debug=debug, max_workers=workers
+            forest,
+            tau=tau,
+            decay=decay,
+            epoch=epoch,
+            min_support=min_support,
+            schema_similarity=(similarity == SimilarityMode.schema),
+            debug=debug,
+            max_workers=workers,
         )
 
         # Generate schema

--- a/architxt/schema.py
+++ b/architxt/schema.py
@@ -7,7 +7,7 @@ from collections import Counter, defaultdict
 from enum import Enum, auto
 from functools import cached_property
 from itertools import combinations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 from antlr4 import CommonTokenStream, InputStream
@@ -18,7 +18,6 @@ from tqdm.auto import tqdm
 
 from architxt.grammar.metagrammarLexer import metagrammarLexer
 from architxt.grammar.metagrammarParser import metagrammarParser
-from architxt.similarity import jaccard
 from architxt.tree import Forest, NodeLabel, NodeType, Tree, TreeOID, has_type
 
 if TYPE_CHECKING:
@@ -82,6 +81,16 @@ class Schema(CFG):
         super().__init__(Nonterminal('ROOT'), [root_production, *productions])
         self._groups = groups
         self._relations = relations
+
+    def __or__(self, other: Any) -> Schema:
+        if not isinstance(other, Schema):
+            return NotImplemented
+
+        return Schema(
+            self.productions() + other.productions(),
+            self.groups | other.groups,
+            self.relations | other.relations,
+        )
 
     @staticmethod
     def _get_rank(nt: Nonterminal) -> int:
@@ -291,6 +300,8 @@ class Schema(CFG):
         :return: The group overlap ratio as a float value between 0 and 1.
                  A higher value indicates a higher degree of overlap between groups.
         """
+        from architxt.similarity import jaccard
+
         jaccard_indices = [jaccard(group1.entities, group2.entities) for group1, group2 in combinations(self.groups, 2)]
 
         # Combine scores (average of pairwise indices)
@@ -339,6 +350,36 @@ class Schema(CFG):
         :returns: The schema as a list of production rules, each terminated by a semicolon.
         """
         return '\n'.join(f"{prod};" for prod in self.productions())
+
+    def to_tree(self) -> Tree:
+        """
+        Convert the schema (CFG) into a single template tree rooted at 'ROOT'.
+
+        Each symbol in the schema is expanded recursively starting from the start symbol.
+
+        :return: A template tree representing the schema.
+
+        >>> schema = Schema.from_description(
+        ...     groups={
+        ...         Group('G1', {'A', 'B'}),
+        ...         Group('G2', {'A', 'C', 'D'}),
+        ...     },
+        ...     relations={
+        ...         Relation('R1', 'G1', 'G2', RelationOrientation.LEFT),
+        ...     },
+        ...     collections=False
+        ... )
+        >>> print(schema.to_tree())
+        (ROOT (GROUP::G1 (ENT::A ) (ENT::B )) (GROUP::G2 (ENT::A ) (ENT::C ) (ENT::D )) (REL::R1 (GROUP::G1 (ENT::A ) (ENT::B )) (GROUP::G2 (ENT::A ) (ENT::C ) (ENT::D ))))
+        """
+
+        def expand(lhs: Nonterminal) -> Tree:
+            prods = self.productions(lhs=lhs)
+            children = [expand(rhs) if isinstance(rhs, Nonterminal) else rhs for prod in prods for rhs in prod.rhs()]
+
+            return Tree(lhs.symbol(), children)
+
+        return expand(self.start())
 
     def extract_valid_trees(self, forest: Iterable[Tree]) -> Generator[Tree, None, None]:
         """

--- a/architxt/similarity.py
+++ b/architxt/similarity.py
@@ -20,7 +20,8 @@ from scipy.spatial.distance import squareform
 from tqdm.auto import tqdm
 
 from architxt.bucket import TreeBucket
-from architxt.tree import Forest, NodeType, Tree, TreeOID, TreePersistentRef, has_type
+from architxt.schema import Schema
+from architxt.tree import Forest, NodeLabel, NodeType, Tree, TreeOID, TreePersistentRef, has_type
 
 __all__ = [
     'DECAY',
@@ -101,7 +102,7 @@ def similarity(
 
     The function uses a specified metric (such as Jaccard, Levenshtein, or Jaro-Winkler) to calculate the
     similarity between the labels of entities in the trees. The similarity is computed as a recursive weighted
-    mean for each tree anestor, where the weight decays with the distance from the tree.
+    mean for each tree ancestor, where the weight decays with the distance from the tree.
 
     .. math::
         \text{similarity}_\text{metric}(x, y) =
@@ -209,6 +210,7 @@ class TreeClusterer:
         max_sim_ctx_depth: int = MAX_SIM_CTX_DEPTH,
         max_height: int = 5,
         min_cluster_size: int = 2,
+        schema_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """
@@ -225,6 +227,8 @@ class TreeClusterer:
         :param max_sim_ctx_depth: The maximum depth of context to consider when computing similarity.
         :param max_height: The maximum height of subtrees to consider for clustering.
         :param min_cluster_size: The minimum size of a cluster
+        :param schema_only: If True the clustering will be done on the schema instead of the instance.
+                            It can improve performance but may not give the same result as with the instance.
         """
         _validate_tau(tau)
         _validate_decay(decay)
@@ -234,6 +238,7 @@ class TreeClusterer:
         self._metric = metric
         self._max_sim_ctx_depth = max_sim_ctx_depth
         self._max_height = max_height
+        self._schema_only = schema_only
         self._clusterer = HDBSCAN(
             metric='precomputed',
             cluster_selection_epsilon=1 - self._tau,
@@ -288,7 +293,26 @@ class TreeClusterer:
             return
 
         # Compute distance matrix for all subtrees
-        dist_matrix = self._compute_dist_matrix(subtrees)
+        if self._schema_only:
+            schema = Schema.from_forest(forest)
+            schema_tree = schema.to_tree()
+            schema_subtrees = tuple(
+                schema_tree.subtrees(
+                    lambda x: (
+                        x.height <= self._max_height and not has_type(x, NodeType.ENT) and not x.has_duplicate_entity()
+                    )
+                )
+            )
+            subtrees_mapping: dict[NodeLabel | str, list[int]] = defaultdict(list)
+            for i, st in enumerate(subtrees):
+                if st := self._get_tree(st):
+                    subtrees_mapping[st.label].append(i)
+            dist_matrix = self._compute_dist_matrix(schema_subtrees)
+
+        else:
+            schema_subtrees = ()
+            subtrees_mapping = {}
+            dist_matrix = self._compute_dist_matrix(subtrees)
 
         # HDBSCAN does not like zero distances, so we add a bit of jitter
         # We use a tiny uniform noise on exact zeros to breaks ties without changing semantics
@@ -300,24 +324,36 @@ class TreeClusterer:
 
         # Perform hierarchical clustering based on the distance threshold tau
         labels = self._clusterer.fit_predict(squareform(dist_matrix))
+        probabilities = np.ones(len(subtrees)) if self._schema_only else self._clusterer.probabilities_
 
         # Group subtrees by cluster ID
         subtree_clusters = defaultdict(list)
         for idx, cluster_id in enumerate(labels):
             if cluster_id != -1:
-                subtree_clusters[cluster_id].append(idx)
+                if self._schema_only:
+                    subtrees_ids = subtrees_mapping[schema_subtrees[idx].label]
+                    subtree_clusters[cluster_id].extend(subtrees_ids)
+                else:
+                    subtree_clusters[cluster_id].append(idx)
 
-        # Sort clusters based on the HDBSCAN membership probability within the cluster.
+        self._reconstruct_clusters(subtree_clusters, subtrees, probabilities)
+
+    def _reconstruct_clusters(
+        self,
+        subtree_clusters: dict[int, list[int]],
+        subtrees: Sequence[Tree | TreePersistentRef],
+        probabilities: npt.NDArray[np.float64],
+    ) -> None:
+        # Sort clusters based on the membership probability within the cluster.
         for cluster_num, cluster_indices in enumerate(subtree_clusters.values()):
-            if len(cluster_indices) == 1:
+            if len(cluster_indices) < 2:
                 continue
 
             # Sort the cluster based on their membership probability
-            cluster_probabilities = self._clusterer.probabilities_
-            sorted_indices = sorted(cluster_indices, key=lambda i: cluster_probabilities[i], reverse=True)
+            sorted_indices = sorted(cluster_indices, key=lambda i: probabilities[i], reverse=True)
             tree_cluster = TreeCluster(
                 trees=tuple(subtrees[i] for i in sorted_indices),
-                probabilities=np.asarray(cluster_probabilities[sorted_indices], dtype=np.float64),
+                probabilities=np.asarray(probabilities[sorted_indices], dtype=np.float64),
             )
 
             # Get the most common label for the cluster
@@ -481,6 +517,7 @@ def entity_labels(
     tau: float,
     metric: METRIC_FUNC | None = DEFAULT_METRIC,
     decay: float = DECAY,
+    schema_only: bool = False,
 ) -> dict[TreeOID, str]:
     """
     Process the given forest to assign labels to entities based on clustering of their ancestor.
@@ -491,6 +528,7 @@ def entity_labels(
         If None, use the parent label as the equivalent class.
     :param decay: The similarity decay factor.
         The higher the value, the more the weight of context decreases with distance.
+    :param schema_only: If True the clustering will be done on the schema instead of the instance.
     :return: A dictionary mapping entities to their respective cluster name.
     """
     _validate_tau(tau)
@@ -503,7 +541,7 @@ def entity_labels(
         for tree in forest
         for subtree in tree.subtrees(lambda x: not has_type(x, NodeType.ENT) and x.has_entity_child())
     ]
-    clusterer = TreeClusterer(tau=tau, metric=metric, decay=decay)
+    clusterer = TreeClusterer(tau=tau, metric=metric, decay=decay, schema_only=schema_only)
     clusterer.fit(entity_parents, _all_subtrees=False)
 
     return {

--- a/architxt/simplification/tree_rewriting/__init__.py
+++ b/architxt/simplification/tree_rewriting/__init__.py
@@ -66,6 +66,7 @@ def rewrite(
     max_workers: int | None = None,
     commit: bool | int = True,
     simplify_names: bool = True,
+    schema_similarity: bool = False,
 ) -> Metrics:
     """
     Rewrite a forest by applying edit operations iteratively.
@@ -88,6 +89,7 @@ def rewrite(
         When using TreeBucket, workers always commit in internal transactions (to avoid serialization).
         The commit parameter only controls the batch size for these commits.
     :param simplify_names: Should the groups/relations names be simplified after the rewrite?
+    :param schema_similarity: Should the similarity be computed on the schema instead of the instance?
 
     :return: A `Metrics` object encapsulating the results and metrics calculated for the rewrite process.
     """
@@ -99,7 +101,7 @@ def rewrite(
     batch_size = get_commit_batch_size(commit)
     min_support = min_support or max((len(forest) // 10), 2)
     max_workers = max_workers or min(len(forest) // batch_size, (cpu_count() - 2)) or 1
-    tree_clusterer = TreeClusterer(tau=tau, decay=decay, metric=metric)
+    tree_clusterer = TreeClusterer(tau=tau, decay=decay, metric=metric, schema_only=schema_similarity)
 
     if debug:
         print('workers :', max_workers, '| batch size :', batch_size)

--- a/architxt/ui/page/simplification.py
+++ b/architxt/ui/page/simplification.py
@@ -16,10 +16,18 @@ def _render_rule_based_simplification(forest: TreeBucket) -> None:
     decay = c2.number_input('Decay', min_value=0.0, value=2.0)
     min_support = c1.number_input('Min Support', min_value=1, value=10)
     epoch = c2.number_input('Epochs', min_value=1, value=50)
+    schema_similarity = st.selectbox("Compute similarity on", ('instance', 'schema'), index=0)
 
     if st.button("Apply Rule-Based Simplification"):
         with st.spinner("Simplifying..."):
-            rewrite(forest, tau=tau, decay=decay, epoch=epoch, min_support=min_support)
+            rewrite(
+                forest,
+                tau=tau,
+                decay=decay,
+                epoch=epoch,
+                min_support=min_support,
+                schema_similarity=schema_similarity == 'schema',
+            )
 
         update_metrics()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a similarity mode option ("instance" or "schema") across CLI and web UI.
  * Rule-based simplification can now compute similarity using schema-level or instance-level representations.
  * Clustering/simplification behavior respects the selected similarity mode for more flexible grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->